### PR TITLE
Added password change endpoint with complete implementation

### DIFF
--- a/src/main/java/com/example/demo/dao/AuthDao.java
+++ b/src/main/java/com/example/demo/dao/AuthDao.java
@@ -222,19 +222,35 @@ public class AuthDao {
     }
 
 
-    public User findCustomerById(int profileId) {
+    public Customer findCustomerById(int profileId) {
         String sql= "SELECT * FROM Customer WHERE customer_id=?";
         return jdbcTemplate.queryForObject(sql,new CustomerRowMapper(),profileId);
     }
 
-    public User findVendorById(int profileId) {
+    public Vendor findVendorById(int profileId) {
         String sql= "SELECT * FROM Vendor WHERE vendor_id=?";
         return jdbcTemplate.queryForObject(sql,new VendorRowMapper(),profileId);
     }
 
-    public User findStaffById(int profileId) {
+    public Staff findStaffById(int profileId) {
         String sql= "SELECT * FROM Staff WHERE staff_id=?";
         return jdbcTemplate.queryForObject(sql,new StaffRowMapper(),profileId);
+    }
+
+    //    password update
+    public void updateCustomerPassword(Integer customerId, String newHashedPassword) {
+        String sql = "UPDATE Customer SET password = ? WHERE customer_id = ?";
+        jdbcTemplate.update(sql, newHashedPassword, customerId);
+    }
+
+    public void updateVendorPassword(Integer vendorId, String newHashedPassword) {
+        String sql = "UPDATE Vendor SET password = ? WHERE vendor_id = ?";
+        jdbcTemplate.update(sql, newHashedPassword, vendorId);
+    }
+
+    public void updateStaffPassword(Integer staffId, String newHashedPassword) {
+        String sql = "UPDATE Staff SET password = ? WHERE staff_id = ?";
+        jdbcTemplate.update(sql, newHashedPassword, staffId);
     }
 
     private static class CustomerRowMapper implements RowMapper<Customer> {

--- a/src/main/java/com/example/demo/dto/PasswordChangeRequestDto.java
+++ b/src/main/java/com/example/demo/dto/PasswordChangeRequestDto.java
@@ -1,0 +1,56 @@
+package com.example.demo.dto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class PasswordChangeRequestDto {
+
+    @NotBlank(message = "Current password must not be blank")
+    private String currentPassword;
+
+    @NotBlank(message = "New password must not be blank")
+    @Size(min = 8, max = 100, message = "Password must be between 8 and 100 characters")
+    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=]).*$",
+              message = "Password must contain at least one digit, one lowercase, one uppercase, and one special character.")
+    private String newPassword;
+
+    @NotBlank(message = "Confirmation password must not be blank")
+    private String confirmPassword;
+
+    // --- Constructors ---
+
+    public PasswordChangeRequestDto() {
+    }
+
+    public PasswordChangeRequestDto(String currentPassword, String newPassword, String confirmPassword) {
+        this.currentPassword = currentPassword;
+        this.newPassword = newPassword;
+        this.confirmPassword = confirmPassword;
+    }
+
+    // --- Getters and Setters ---
+
+    public String getCurrentPassword() {
+        return currentPassword;
+    }
+
+    public void setCurrentPassword(String currentPassword) {
+        this.currentPassword = currentPassword;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+
+    public String getConfirmPassword() {
+        return confirmPassword;
+    }
+
+    public void setConfirmPassword(String confirmPassword) {
+        this.confirmPassword = confirmPassword;
+    }
+}


### PR DESCRIPTION
authenticate every request using a JWT and then authorize the action by ensuring the user ID from the token matches the profile ID being changed. It also requires the user's current password as a final verification before committing the update. The reason for this multi-layered approach is to prevent unauthorized access, ensure a user can never change another person's password, and confirm the identity of the person making the change, creating a robust and secure feature. Also include some minor change in authDoa (findByEmail)